### PR TITLE
Fix Webpack issue that breaks with TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "module": "commonjs",
         "removeComments": true,
         "experimentalDecorators": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "noEmitHelpers": true
     },
     "files": [
       "demo/node_modules/tns-core-modules/tns-core-modules.d.ts",


### PR DESCRIPTION
Adding `noEmitHelpers` to TypeScript avoid the creating of the `__extends()` function which breaks WebPack.

Read more: 
https://github.com/NativeScript/nativescript-dev-webpack/issues/8
http://stackoverflow.com/questions/36556772/webpack-and-typescript-extends