### PR TITLE
Improve drag & pull down experience on iOS

### DIFF
--- a/src/pulltorefresh.ios.ts
+++ b/src/pulltorefresh.ios.ts
@@ -1,7 +1,7 @@
 /// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />
 /// <reference path="./node_modules/nativescript-ui-listview/platforms/ios/typings/listview.d.ts" />
 
-import { device } from 'tns-core-modules/platform';
+import { ios as iosUtils } from 'tns-core-modules/utils/utils';
 import { Color } from 'tns-core-modules/color';
 import {
   PullToRefreshBase,
@@ -37,7 +37,7 @@ class PullToRefreshHandler extends NSObject {
   }
 }
 
-const SUPPORT_REFRESH_CONTROL = parseFloat(device.osVersion) >= 10.0;
+const SUPPORT_REFRESH_CONTROL = iosUtils.MajorVersion >= 10;
 
 export class PullToRefresh extends PullToRefreshBase {
   private _handler: PullToRefreshHandler;

--- a/src/pulltorefresh.ios.ts
+++ b/src/pulltorefresh.ios.ts
@@ -1,6 +1,7 @@
 /// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />
 /// <reference path="./node_modules/nativescript-ui-listview/platforms/ios/typings/listview.d.ts" />
 
+import { device } from 'tns-core-modules/platform';
 import { Color } from 'tns-core-modules/color';
 import {
   PullToRefreshBase,
@@ -36,6 +37,8 @@ class PullToRefreshHandler extends NSObject {
   }
 }
 
+const SUPPORT_REFRESH_CONTROL = parseFloat(device.osVersion) >= 10.0;
+
 export class PullToRefresh extends PullToRefreshBase {
   private _handler: PullToRefreshHandler;
 
@@ -58,27 +61,44 @@ export class PullToRefresh extends PullToRefreshBase {
     super.onLoaded();
 
     if (this.content.ios instanceof UIScrollView) {
-      // ensure that we can trigger the refresh, even if the content is not large enough
-      this.content.ios.alwaysBounceVertical = true;
+      if (SUPPORT_REFRESH_CONTROL) {
+        this.content.ios.refreshControl = this.refreshControl;
+      } else {
+        // ensure that we can trigger the refresh, even if the content is not large enough
+        this.content.ios.alwaysBounceVertical = true;
 
-      this.content.ios.addSubview(this.refreshControl);
+        this.content.ios.addSubview(this.refreshControl);
+      }
     } else if (this.content.ios instanceof UIWebView) {
-      // ensure that we can trigger the refresh, even if the content is not large enough
-      this.content.ios.scrollView.alwaysBounceVertical = true;
+      if (SUPPORT_REFRESH_CONTROL) {
+        this.content.ios.scrollView.refreshControl = this.refreshControl;
+      } else {
+        // ensure that we can trigger the refresh, even if the content is not large enough
+        this.content.ios.scrollView.alwaysBounceVertical = true;
 
-      this.content.ios.scrollView.addSubview(this.refreshControl);
+        this.content.ios.scrollView.addSubview(this.refreshControl);
+      }
     } else if (
       typeof TKListView !== 'undefined' &&
       this.content.ios instanceof TKListView
     ) {
-      // ensure that we can trigger the refresh, even if the content is not large enough
-      this.content.ios.collectionView.alwaysBounceVertical = true;
-      this.content.ios.collectionView.addSubview(this.refreshControl);
-    } else if (this.content.ios instanceof WKWebView) {
-      // ensure that we can trigger the refresh, even if the content is not large enough
-      this.content.ios.scrollView.alwaysBounceVertical = true;
+      if (SUPPORT_REFRESH_CONTROL) {
+        this.content.ios.collectionView.refreshControl = this.refreshControl;
+      } else {
+        // ensure that we can trigger the refresh, even if the content is not large enough
+        this.content.ios.collectionView.alwaysBounceVertical = true;
 
-      this.content.ios.scrollView.addSubview(this.refreshControl);
+        this.content.ios.collectionView.addSubview(this.refreshControl);
+      }
+    } else if (this.content.ios instanceof WKWebView) {
+      if (SUPPORT_REFRESH_CONTROL) {
+        this.content.ios.scrollView.refreshControl = this.refreshControl;
+      } else {
+        // ensure that we can trigger the refresh, even if the content is not large enough
+        this.content.ios.scrollView.alwaysBounceVertical = true;
+
+        this.content.ios.scrollView.addSubview(this.refreshControl);
+      }
     } else {
       throw new Error(
         'Content must inherit from either UIScrollView, UIWebView or WKWebView!'


### PR DESCRIPTION
When `UIScrollView` does not take full screen (half of the screen in my case), it is challenging to activate `UIRefreshControl` when it added in old fashion (by `addSubview` method), but when it added in new fashion (by `refreshControl` property), everything works smoothly.

To see the difference in action you could read [this StackOverflow answer](https://stackoverflow.com/a/43288926/9967488).
